### PR TITLE
Add TR3 autosplitter

### DIFF
--- a/LiveSplit.TR3.asl
+++ b/LiveSplit.TR3.asl
@@ -1,40 +1,156 @@
-state("tomb3", "US")
+state("tomb3", "INT")
 {
-    int isCutscene:    0x233F54;
-    int isStatsScreen: 0x2266AC;
-    int isTitle:       0x2A1B78;
-    int level:         0xC561C;
+    // true during cutscene, false otherwise
+    bool isCutscene: 0x233F54;
+
+    // true while stats screen is showing, false otherwise
+    bool isStatsScreen: 0x2266AC;
+
+    // true on the title screen, false otherwise
+    bool isTitle: 0x2A1C58;
+
+    // 00: Manor
+    // India
+    // 01: Jungle
+    // 02: Temple Ruins
+    // 03: The River Ganges
+    // 04: Caves of Kaliya
+    // South Pacific
+    // 05: Coastal Village
+    // 06: Crash Site
+    // 07: Madubu Gorge
+    // 08: Temple of Puna
+    // London
+    // 09: Thames Wharf
+    // 10: Aldwych
+    // 11: Lud's Gate
+    // 12: City
+    // Nevada
+    // 13: Nevada Desert
+    // 14: High Security Compound
+    // 15: Area 51
+    // Antarctica
+    // 16: Antarctica
+    // 17: RX-Tech Mines
+    // 18: Lost City of Tinnos
+    // 19: Meteorite Cavern
+    // Bonus (All Secrets)
+    // 20: All Hallows
+    uint level: 0xC561C;
+
+    // Current level time as measured by in-game "ticks" (30 / second)
+    uint levelTime: 0x2D27CF;
+
+    // 0 if Load Game was picked.
+    // Changes to 1 when choosing New Game or Save Game.
+    // The value stays 1 until the inventory is reopened.
+    // The value is always 2 when using the Exit To Title or Exit Game pages.
+    // Anywhere else the value is 0.
+    uint pickedPassportFunction: 0x226458;
 }
 
 state("tomb3", "JP")
 {
-    int isCutscene:    0x233F44;
-    int isStatsScreen: 0x2266AC;
-    int isTitle:       0x2A1B80;
-    int level:         0xC561C;
+    int isCutscene:              0x233F44;
+    bool isStatsScreen:          0x2266AC;
+    bool isTitle:                0x2A1C60;
+    uint level:                  0xC561C;
+    uint levelTime:              0x2D27CF;
+    uint pickedPassportFunction: 0x226458;
+}
+
+startup
+{
+    // No need for specific FG rulesets/categories because this
+    // splitter (if coded properly) will work with any category
+    // including Any%, Secrets, and 100/Max% (with known speedrunning tech).
+    settings.Add("FG", true, "Full Game");
+    settings.SetToolTip("FG", "A full game run, as opposed to an IL (Individual Level) run.");
+    settings.Add("IL", false, "Individual Level - RTA");
+    settings.SetToolTip("IL", "RTA (Real-Time Attack) ILs; do not use this for IGT (In-Game Time) ILs nor full-game runs.");
 }
 
 init
 {
-    // TODO: Differentiate and set the version according to which one is running.
-    // Both version's ModuleMemorySize == 3141632, so that method won't work.
-    Console.Writeline("Process found!");
-    const uint refreshRate = 30;
+    // See: https://github.com/rtrger/Components/blob/master/TombRaiderTheAngelofDarkness.asl#L223
+    // for hash code inspiration.
+    var versionHashes = new Dictionary<string, string>
+    {
+        {"4044dc2c58f02bfea2572e80dd8f2abb", "INT"},
+        {"66404f58bb5dbf30707abfd245692cd2", "JP"}
+    };
+
+    string exePath = game.MainModule.FileName;
+    string hashInHex = "0";
+    using (var md5 = System.Security.Cryptography.MD5.Create())
+    {
+        using (var stream = File.Open(exePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+        {
+            var hash = md5.ComputeHash(stream);
+            hashInHex = BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+        }
+    }
+
+    foreach (KeyValuePair<string, string> kvp in versionHashes)
+    {
+        if (kvp.Key == hashInHex)
+        {
+            version = kvp.Value;
+            return;
+        }
+    }
+    version = "Unrecognized";
 }
 
 start
 {
-    return current.level == 1 && current.isTitle == 0 && old.isTitle == 1;
+    bool newGameStarted = current.level == 1 && current.levelTime == 0 && old.isTitle;
+    if (newGameStarted)
+        return true;
+
+    if (settings["FG"])
+    {
+        return false;
+    }
+    else  // IL-specific logic
+    {
+        bool goingToNextRealLevel = current.level == old.level + 1 && current.levelTime == 0;
+        return goingToNextRealLevel;
+    }
 }
 
 reset
 {
-    return current.isTitle == 1 && old.isTitle == 0;
+    return current.pickedPassportFunction == 2;
 }
 
+// TODO: Create IL split logic.
 split
 {
     if (current.level == 19)
-        return current.isCutscene == 1 && old.isCutscene == 0;
-    return current.isStatsScreen == 1 && old.isStatsScreen == 0;
+        return current.isCutscene && !old.isCutscene;
+    return current.isStatsScreen && !old.isStatsScreen;
+}
+
+// Copied from rtrger's TR3G ASL with IntPtr value and some var names changed.
+// TODO: Adjust the loop and/or other logic to account for unenforced level order.
+gameTime
+{
+    const int ticksPerSecond = 30;
+
+    if (settings["IL"])
+    {
+        return TimeSpan.FromSeconds((double) current.levelTime / ticksPerSecond);
+    }
+    else
+    {
+        var firstLevelTime = (IntPtr)0x6D2326;
+        int finishedLevelsTime = 0;
+        // The game stores statistics (including time) for each completed level on separate addresses.
+        for (int i = 0; i < (current.level - 1); i++)
+        {
+            finishedLevelsTime += memory.ReadValue<int>((IntPtr)(firstLevelTime + (i * 0x33)));
+        }
+        return TimeSpan.FromSeconds((double) (current.levelTime + finishedLevelsTime) / ticksPerSecond);
+    }
 }

--- a/LiveSplit.TR3.asl
+++ b/LiveSplit.TR3.asl
@@ -1,0 +1,40 @@
+state("tomb3", "US")
+{
+    int isCutscene:    0x233F54;
+    int isStatsScreen: 0x2266AC;
+    int isTitle:       0x2A1B78;
+    int level:         0xC561C;
+}
+
+state("tomb3", "JP")
+{
+    int isCutscene:    0x233F44;
+    int isStatsScreen: 0x2266AC;
+    int isTitle:       0x2A1B80;
+    int level:         0xC561C;
+}
+
+init
+{
+    // TODO: Differentiate and set the version according to which one is running.
+    // Both version's ModuleMemorySize == 3141632, so that method won't work.
+    Console.Writeline("Process found!");
+    const uint refreshRate = 30;
+}
+
+start
+{
+    return current.level == 1 && current.isTitle == 0 && old.isTitle == 1;
+}
+
+reset
+{
+    return current.isTitle == 1 && old.isTitle == 0;
+}
+
+split
+{
+    if (current.level == 19)
+        return current.isCutscene == 1 && old.isCutscene == 0;
+    return current.isStatsScreen == 1 && old.isStatsScreen == 0;
+}

--- a/LiveSplit.TR3.asl
+++ b/LiveSplit.TR3.asl
@@ -151,11 +151,13 @@ split
     else
         shouldSplit = current.levelComplete && current.isStatsScreen && !old.isStatsScreen;
 
+    var index = vars.completedLevels.IndexOf(current.level);
+    bool levelWasAlreadyCompleted = index != -1;
+
     // Handle completed level and time arrays for full-game runs.
     if (shouldSplit && settings["FG"])
     {
-        var index = vars.completedLevels.IndexOf(current.level);
-        if (index != -1)
+        if (levelWasAlreadyCompleted)
         {
             // If the level was previously completed, overwrite the existing time.
             vars.completedLevelTimes[index] = current.currentLevelTime;
@@ -168,7 +170,7 @@ split
         }
     }
 
-    return shouldSplit;
+    return shouldSplit && !levelWasAlreadyCompleted;
 }
 
 // Inspired by rtrger's TR3G ASL's gameTime block.

--- a/LiveSplit.TR3.asl
+++ b/LiveSplit.TR3.asl
@@ -86,7 +86,7 @@ startup
 
 init
 {
-    // See: https://github.com/rtrger/Components/blob/master/TombRaiderTheAngelofDarkness.asl#L223
+    // See: https://github.com/rtrger/Components/blob/master/TombRaiderTheAngelofDarkness.asl
     // for hash code inspiration.
     var versionHashes = new Dictionary<string, string>
     {
@@ -173,7 +173,6 @@ split
     return shouldSplit && !levelWasAlreadyCompleted;
 }
 
-// Inspired by rtrger's TR3G ASL's gameTime block.
 gameTime
 {
     const uint ticksPerSecond = 30;


### PR DESCRIPTION
Adds a TR3 autosplitter with start, split, reset, and IGT support. Works with all srcom-legal versions for ILs as well as full-game NG and NG+ runs using any level order.