### PR TITLE
Improved IL Start logic.

### DIFF
--- a/LiveSplit.TR3.asl
+++ b/LiveSplit.TR3.asl
@@ -132,8 +132,8 @@ start
     }
     else  // IL-specific logic
     {
-        bool goingToAnotherLevel = old.isStatsScreen && !current.isStatsScreen && current.currentLevelTime == 0;
-        return goingToAnotherLevel;
+        bool goingFromOneLevelToAnother = old.level != current.level && current.currentLevelTime == 0;
+        return goingFromOneLevelToAnother;
     }
 }
 


### PR DESCRIPTION
Fixed issues the existing IL `Start` logic had. For JP, IL only reliably `Start`ed for New Game, but apparently never for the actual IL logic. For INT, the levels would generally fail to `Start` when there was a world select or cutscene before the level.

This fix decides to ignore any stats screen or cutscenes between levels and simply looks to see if both the level has changed and the current level's time is 0.