### PR TITLE
Fix the timer so it doesn't start during unplayable time.

### DIFF
--- a/LiveSplit.TR3.asl
+++ b/LiveSplit.TR3.asl
@@ -118,7 +118,8 @@ init
 
 start
 {
-    bool newGameStarted = current.level <= 20 && current.currentLevelTime == 0 && old.isTitle;
+    bool levelTimeJustStarted = old.currentLevelTime == 0 && current.currentLevelTime != 0;
+    bool newGameStarted = levelTimeJustStarted && current.pickedPassportFunction == 1;
     if (newGameStarted)
     {
         vars.completedLevels.Clear();
@@ -127,14 +128,9 @@ start
     }
 
     if (settings["FG"])
-    {
         return false;
-    }
     else  // IL-specific logic
-    {
-        bool goingFromOneLevelToAnother = old.level != current.level && current.currentLevelTime == 0;
-        return goingFromOneLevelToAnother;
-    }
+        return levelTimeJustStarted && !old.isTitle;
 }
 
 reset


### PR DESCRIPTION
Previously, the timer was starting when something like the stats screen flag or level number changed. With the changes from this branch, it would start at the first IGT increment, which also represents the point at which the player gains control during the fade-in.