### PR TITLE
Updated XMLs to use localPath.

### DIFF
--- a/TombRaider1996/Components/update.xml
+++ b/TombRaider1996/Components/update.xml
@@ -1,8 +1,8 @@
 <updates>
   <update version="3.1.1.0">
     <files>
-      <file path="TombRaider1996/Components/TR1996.dll" status="changed"/>
-      <file path="TRUtil/Components/TRUtil.dll" status="changed"/>
+      <file path="TombRaider1996/Components/TR1996.dll" localPath="Components/TR1996.dll" status="changed"/>
+      <file path="TRUtil/Components/TRUtil.dll" localPath="Components/TRUtil.dll" status="changed"/>
     </files>
     <changelog>
       <change>TRUtil changes for later classics.</change>
@@ -12,8 +12,8 @@
     <files>
       <file path="Components/TR1996.dll" status="removed"/>
       <file path="Components/TRUtil.dll" status="removed"/>
-      <file path="TombRaider1996/Components/TR1996.dll" status="added"/>
-      <file path="TRUtil/Components/TRUtil.dll" status="added"/>
+      <file path="TombRaider1996/Components/TR1996.dll" localPath="Components/TR1996.dll" status="added"/>
+      <file path="TRUtil/Components/TRUtil.dll" localPath="Components/TRUtil.dll" status="added"/>
     </files>
     <changelog>
       <change>Simplified TRUtil DLL distribution.</change>

--- a/TombRaiderII/Components/update.xml
+++ b/TombRaiderII/Components/update.xml
@@ -1,8 +1,8 @@
 <updates>
   <update version="1.4.1.0">
     <files>
-      <file path="TombRaiderII/Components/TR2.dll" status="changed"/>
-      <file path="TRUtil/Components/TRUtil.dll" status="changed"/>
+      <file path="TombRaiderII/Components/TR2.dll" localPath="Components/TR2.dll" status="changed"/>
+      <file path="TRUtil/Components/TRUtil.dll" localPath="Components/TRUtil.dll" status="changed"/>
     </files>
     <changelog>
       <change>TRUtil changes for later classics.</change>
@@ -12,8 +12,8 @@
     <files>
       <file path="Components/TR2.dll" status="removed"/>
       <file path="Components/TRUtil.dll" status="removed"/>
-      <file path="TombRaiderII/Components/TR2.dll" status="added"/>
-      <file path="TRUtil/Components/TRUtil.dll" status="added"/>
+      <file path="TombRaiderII/Components/TR2.dll" localPath="Components/TR2.dll" status="added"/>
+      <file path="TRUtil/Components/TRUtil.dll" localPath="Components/TRUtil.dll" status="added"/>
     </files>
     <changelog>
       <change>Simplified TRUtil DLL distribution.</change>

--- a/TombRaiderIII/Components/update.xml
+++ b/TombRaiderIII/Components/update.xml
@@ -1,8 +1,8 @@
 <updates>
   <update version="2.0.1.0">
     <files>
-      <file path="TombRaiderIII/Components/TR3.dll" status="changed"/>
-      <file path="TRUtil/Components/TRUtil.dll" status="changed"/>
+      <file path="TombRaiderIII/Components/TR3.dll" localPath="Components/TR3.dll" status="changed"/>
+      <file path="TRUtil/Components/TRUtil.dll" localPath="Components/TRUtil.dll" status="changed"/>
     </files>
     <changelog>
       <change>TRUtil changes for later classics.</change>
@@ -10,8 +10,8 @@
   </update>
   <update version="2.0.0.0">
     <files>
-      <file path="TombRaiderIII/Components/TR3.dll" status="changed"/>
-      <file path="TRUtil/Components/TRUtil.dll" status="changed"/>
+      <file path="TombRaiderIII/Components/TR3.dll" localPath="Components/TR3.dll" status="changed"/>
+      <file path="TRUtil/Components/TRUtil.dll" localPath="Components/TRUtil.dll" status="changed"/>
     </files>
     <changelog>
       <change>Now supports The Lost Artifact (JP Gold Bundle).</change>
@@ -21,8 +21,8 @@
     <files>
       <file path="Components/TR3.dll" status="removed"/>
       <file path="Components/TRUtil.dll" status="removed"/>
-      <file path="TombRaiderIII/Components/TR3.dll" status="added"/>
-      <file path="TRUtil/Components/TRUtil.dll" status="added"/>
+      <file path="TombRaiderIII/Components/TR3.dll" localPath="Components/TR3.dll" status="added"/>
+      <file path="TRUtil/Components/TRUtil.dll" localPath="Components/TRUtil.dll" status="added"/>
     </files>
     <changelog>
       <change>Simplified TRUtil DLL distribution.</change>

--- a/TombRaiderV/Components/update.xml
+++ b/TombRaiderV/Components/update.xml
@@ -1,8 +1,8 @@
 <updates>
   <update version="1.1.0.0">
     <files>
-      <file path="TombRaiderV/Components/TR5.dll" status="added"/>
-      <file path="TRUtil/Components/TRUtil.dll" status="added"/>
+      <file path="TombRaiderV/Components/TR5.dll" localPath="Components/TR5.dll" status="changed"/>
+      <file path="TRUtil/Components/TRUtil.dll" localPath="Components/TRUtil" status="changed"/>
     </files>
     <changelog>
       <change>Added Settings option to disable automatic reset.</change>
@@ -10,8 +10,8 @@
   </update>
   <update version="1.0.0.0">
     <files>
-      <file path="TombRaiderV/Components/TR5.dll" status="added"/>
-      <file path="TRUtil/Components/TRUtil.dll" status="added"/>
+      <file path="TombRaiderV/Components/TR5.dll" localPath="Components/TR5.dll" status="added"/>
+      <file path="TRUtil/Components/TRUtil.dll" localPath="Components/TRUtil" status="added"/>
     </files>
     <changelog>
       <change>Automatic start, split, reset, and IGT for FG, IL, and deathruns.</change>


### PR DESCRIPTION
Combined with each autosplitter's `ComponentFactory` using the base repository URL as `UpdateURL` and the relative path to the update.xml as `UpdateURL`: 

The XMLs can make use of the recently-updated `UpdateManager` featuring `localPath` (see: [1.8.22](https://github.com/LiveSplit/LiveSplit/releases/tag/1.8.22)).